### PR TITLE
Catch errors in scripts

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -97,4 +97,4 @@ async function start() {
   }
 }
 
-start()
+start().catch(console.error)

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -70,9 +70,9 @@ function reloadElectron() {
 /**
  * Start vite dev server for renderer process and listen 8080 port
  */
-function startRenderer() {
+async function startRenderer() {
   const config = require('./vite.config')
-  createServer(config).listen(8080)
+  await createServer(config).listen(8080)
 }
 
 async function startMain() {
@@ -103,5 +103,7 @@ async function startMain() {
   })
 }
 
-startMain()
-startRenderer()
+Promise.all([
+  startMain(),
+  startRenderer(),
+]).catch(console.error)


### PR DESCRIPTION
I suggest adding some changes to the scripts. This will allow you to catch errors and display them in a clearer way.
Now, in case of an error, a not very clear message is displayed:
```
(node:17788) UnhandledPromiseRejectionWarning: ReferenceError: FOOO is not defined
    at startMain (C:\Users\kozac\Dev\electron-vue-next\scripts\dev.js:93:15)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:17788) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with
.catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:17788) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
I would like to make it cleaner and clearer:
```
ReferenceError: FOOO is not defined
    at startMain (C:\Users\kozac\Dev\electron-vue-next\scripts\dev.js:93:15)
    at async Promise.all (index 0)
```