### PR TITLE
chore(dev): Auto-build env.d.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'import/no-absolute-path': 0
   },
   ignorePatterns: [
+    'src/shared/env.d.ts',
     'node_modules/**',
     'dist/**'
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*
 !build/icons
 *.local
 thumbs.db
+src/shared/env.d.ts

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/electron/index.prod.js",
   "scripts": {
     "dev:docs": "node scripts/dev.docs.js",
+    "predev": "node scripts/build.env.js",
     "dev": "node scripts/dev.js",
     "build": "node scripts/build.js",
     "build:docs": "vitepress build docs",

--- a/scripts/build.env.js
+++ b/scripts/build.env.js
@@ -1,0 +1,28 @@
+const { loadEnv } = require('./env.js')
+const { writeFileSync } = require('fs')
+const { resolve } = require('path')
+/**
+ *
+ * @param {string[]} modes
+ */
+function buildMode(modes, filePath) {
+  const interfaces = modes.map(mode => {
+    const name = `${mode}Env`
+    const envs = {
+      MODE: mode,
+      PROD: mode === 'production',
+      DEV: mode !== 'production',
+      ...loadEnv(mode)
+    }
+    const interface = `declare interface ${name} ${JSON.stringify(envs)}`
+
+    return { name, interface }
+  })
+
+  const str = interfaces.map(({ interface }) => interface).join('\n')
+  const name = interfaces.map(({ name }) => name).join(' | ')
+
+  writeFileSync(filePath, `${str}\ndeclare type ImportMetaEnv = ${name}\n`, { encoding: 'utf-8' })
+}
+
+buildMode(['production', 'development'], resolve(process.cwd(), './src/shared/env.d.ts'))

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -28,7 +28,7 @@ function lookupFile(
 /**
  * @returns {Record<string, string>}
  */
-function loadEnv(mode, root) {
+module.exports.loadEnv = function loadEnv(mode, root = process.cwd()) {
   if (mode === 'local') {
     throw new Error(
       '"local" cannot be used as a mode name because it conflicts with ' +
@@ -87,4 +87,4 @@ function loadEnv(mode, root) {
  * Loads environments from files in Vite-style but loads ALL environments
  * @see https://github.com/vitejs/vite#modes-and-environment-variables
  */
-module.exports = loadEnv(process.env.NODE_ENV, process.cwd())
+module.exports.default = module.exports.loadEnv(process.env.NODE_ENV)

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -8,7 +8,7 @@ import builtins from 'builtin-modules'
 import chalk from 'chalk'
 import { startService } from 'esbuild'
 import { extname, join, relative } from 'path'
-const env = require('./env.js')
+const env = require('./env.js').default
 
 // user env variables loaded from .env files.
 // only those prefixed with VITE_ are exposed.

--- a/src/shared/importMeta.d.ts
+++ b/src/shared/importMeta.d.ts
@@ -1,14 +1,11 @@
-/* eslint-disable no-unused-vars */
+/* eslint-disable no-unused-vars, no-undef */
 
 /**
  * @see https://github.com/vitejs/vite/blob/03acecd797d8393e38c8a78f920c8e0927762018/importMeta.d.ts
  */
-declare interface ImportMetaEnv {
+declare interface ImportMetaEnvBase {
   [key: string]: string | boolean | undefined
-  BASE_URL: string
-  MODE: string
-  DEV: boolean
-  PROD: boolean
+  BASE_URL?: string
 }
 
 /**
@@ -31,5 +28,5 @@ declare interface ImportMeta {
     on(event: string, cb: (...args: any[]) => void): void
   }
 
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv & ImportMetaEnvBase
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
   "include": [
     "src/main/**/*",
     "src/shared/**/*",
-    "src/renderer/renderer.d.ts",
+    "src/renderer/renderer.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Added a script that looks for all possible variations of environment variables and forms on their basis Typescript interfaces

BREAKING CHANGE: scripts/env.js now export env object in "default" scope