### PR TITLE
refactor(config): @rollup/plugin-replace replaced by builtin Vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,9 +195,10 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
-      "integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz",
+      "integrity": "sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==",
+      "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "commondir": "^1.0.1",
@@ -227,16 +228,6 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.17.0"
-      }
-    },
-    "@rollup/plugin-replace": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
-      "integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
       }
     },
     "@rollup/plugin-typescript": {
@@ -5285,6 +5276,39 @@
         "ws": "^7.3.1"
       },
       "dependencies": {
+        "@rollup/plugin-commonjs": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+          "integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+          "requires": {
+            "@rollup/pluginutils": "^3.1.0",
+            "commondir": "^1.0.1",
+            "estree-walker": "^2.0.1",
+            "glob": "^7.1.6",
+            "is-reference": "^1.2.1",
+            "magic-string": "^0.25.7",
+            "resolve": "^1.17.0"
+          },
+          "dependencies": {
+            "@rollup/pluginutils": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+              "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+              "requires": {
+                "@types/estree": "0.0.39",
+                "estree-walker": "^1.0.1",
+                "picomatch": "^2.2.2"
+              },
+              "dependencies": {
+                "estree-walker": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+                  "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+                }
+              }
+            }
+          }
+        },
         "@rollup/pluginutils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   ],
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.1",
+    "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-replace": "^2.3.4",
     "@rollup/plugin-typescript": "^6.1.0",
     "@vue/compiler-sfc": "^3.0.2",
+    "builtin-modules": "^3.1.0",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -2,12 +2,13 @@ import pluginAlias from '@rollup/plugin-alias'
 import pluginCommonJs from '@rollup/plugin-commonjs'
 import pluginJson from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
-import pluginReplace from '@rollup/plugin-replace'
 import pluginTypescript from '@rollup/plugin-typescript'
 import builtins from 'builtin-modules'
 import chalk from 'chalk'
 import { startService } from 'esbuild'
 import { extname, join, relative } from 'path'
+import { createReplacePlugin } from 'vite/dist/node/build/buildPluginReplace.js'
+
 const env = require('./env.js')
 
 // user env variables loaded from .env files.
@@ -80,15 +81,19 @@ const config = ({
         '/@shared': join(__dirname, '../src/shared')
       }
     }),
-    pluginReplace({
-      ...userEnvReplacements,
-      ...builtInEnvReplacements,
-      'import.meta.env.': '({}).',
-      'import.meta.env': JSON.stringify({
-        ...userClientEnv,
-        ...builtInClientEnv
-      })
-    }),
+    createReplacePlugin(
+      (id) => id.endsWith('.ts') || id.endsWith('.js'),
+      {
+        ...userEnvReplacements,
+        ...builtInEnvReplacements,
+        'import.meta.env.': '({}).',
+        'import.meta.env': JSON.stringify({
+          ...userClientEnv,
+          ...builtInClientEnv
+        },
+        true
+        )
+      }),
     typescriptPluginInstance,
     {
       name: 'main:esbuild',


### PR DESCRIPTION
Vite uses his own implementation of the plugin for replacement. I suggest using it to get rid of unnecessary dependency.