### PR TITLE
build-optimize

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -342,7 +342,7 @@ The only exception is the `useDialog`. You can only use `async` functions in it 
 
 ### Dependencies Management
 
-If you adding a new dependency, make sure if it's using any **nodejs** module, add it as `excludeOptimize` in the `package.json`. Otherwise, the vite will complain about "I cannot handle it!".
+If you adding a new dependency, make sure if it's using any **nodejs** module, add it as `external` in the `package.json`. Otherwise, the vite will complain about "I cannot handle it!".
 
 ```json
 {
@@ -351,7 +351,7 @@ If you adding a new dependency, make sure if it's using any **nodejs** module, a
     // ...other dependencies
     "a-nodejs-package": "<version>"
   },
-  "excludeOptimize": [
+  "external": [
     // ...other existed excluded packages
     "a-nodejs-package" // your new package
   ],

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -350,7 +350,7 @@ The only exception is the `useDialog`. You can only use `async` functions in it 
 
 ### 管理依赖
 
-如果你想添加新的 npm 包作为依赖使用，你需要注意这个依赖是不是一个基于 nodejs 的模块。如果它是一个 nodejs 的包，你需要把这个包名放进 `package.json` 的 `excludeOptimize` 列表中。这个列表是用于告诉 vite 不要优化某些依赖，如果你不在这里剔除他们，vite就会抱怨说“我优化不了这些！”之类的话。
+如果你想添加新的 npm 包作为依赖使用，你需要注意这个依赖是不是一个基于 nodejs 的模块。如果它是一个 nodejs 的包，你需要把这个包名放进 `package.json` 的 `external` 列表中。这个列表是用于告诉 vite 不要优化某些依赖，如果你不在这里剔除他们，vite就会抱怨说“我优化不了这些！”之类的话。
 
 
 ```json
@@ -360,7 +360,7 @@ The only exception is the `useDialog`. You can only use `async` functions in it 
     // ...other dependencies
     "a-nodejs-package": "<version>"
   },
-  "excludeOptimize": [
+  "external": [
     // ...other existed excluded packages
     "a-nodejs-package" // your new package
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "main": "./dist/electron/index.prod.js",
   "scripts": {
     "dev:docs": "node scripts/dev.docs.js",
     "dev": "node scripts/dev.js",
@@ -26,7 +25,7 @@
     "vue-router": "^4.0.0-beta.13",
     "vuex": "^4.0.0-beta.4"
   },
-  "excludeOptimize": [
+  "external": [
     "electron-updater"
   ],
   "devDependencies": {

--- a/scripts/build.base.config.js
+++ b/scripts/build.base.config.js
@@ -7,7 +7,8 @@ const config = {
   appId: '',
   directories: {
     output: 'build',
-    buildResources: 'build'
+    buildResources: 'build',
+    app: 'dist'
   },
   // assign publish for auto-updater
   // set this to your own repo!
@@ -18,8 +19,6 @@ const config = {
   // }],
   files: [
     // don't include node_modules as all js modules are bundled into production js by rollup
-    '!**/node_modules/**/*',
-    'dist/electron/**/*'
     // unless you want to prevent some module to bundle up
     // list them below
   ]

--- a/scripts/build.base.config.js
+++ b/scripts/build.base.config.js
@@ -6,7 +6,8 @@ const config = {
   productName: '',
   appId: '',
   directories: {
-    output: 'build'
+    output: 'build',
+    buildResources: 'build'
   },
   // assign publish for auto-updater
   // set this to your own repo!

--- a/scripts/dev.docs.js
+++ b/scripts/dev.docs.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk')
 const { createServer } = require('vitepress')
-const { excludeOptimize } = require('../package.json')
+const { external } = require('../package.json')
 
 const port = 3000
 
@@ -9,7 +9,7 @@ async function startVitepress() {
     const server = await createServer({
       root: 'docs',
       optimizeDeps: {
-        exclude: excludeOptimize
+        exclude: external
       }
     })
     server.listen(port, () => {

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -9,6 +9,7 @@ import { startService } from 'esbuild'
 import { extname, join, relative } from 'path'
 import { createReplacePlugin } from 'vite/dist/node/build/buildPluginReplace.js'
 
+import { excludeOptimize } from '../package.json'
 const env = require('./env.js')
 
 // user env variables loaded from .env files.
@@ -63,7 +64,7 @@ const config = ({
       console.log(chalk.yellow(warning.toString()))
     }
   },
-  external: [...builtins, 'electron'],
+  external: [...builtins, 'electron', ...excludeOptimize],
   plugins: [
     {
       name: 'typechecker',
@@ -125,6 +126,9 @@ const config = ({
         }
       },
       async transform(code, id) {
+        if (id.endsWith('js') || id.endsWith('js?commonjs-proxy')) {
+          return
+        }
         function printMessage(m, code) {
           console.error(chalk.yellow(m.text))
           if (m.location) {

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -91,10 +91,9 @@ const config = ({
         'import.meta.env': JSON.stringify({
           ...userClientEnv,
           ...builtInClientEnv
-        },
-        true
-        )
-      }),
+        })
+      },
+      true),
     typescriptPluginInstance,
     {
       name: 'main:esbuild',

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -9,7 +9,7 @@ import { startService } from 'esbuild'
 import { extname, join, relative } from 'path'
 import { createReplacePlugin } from 'vite/dist/node/build/buildPluginReplace.js'
 
-import { excludeOptimize } from '../package.json'
+import { external } from '../package.json'
 const env = require('./env.js')
 
 // user env variables loaded from .env files.
@@ -64,7 +64,7 @@ const config = ({
       console.log(chalk.yellow(warning.toString()))
     }
   },
-  external: [...builtins, 'electron', ...excludeOptimize],
+  external: [...builtins, 'electron', ...external],
   plugins: [
     {
       name: 'typechecker',

--- a/scripts/vite.config.js
+++ b/scripts/vite.config.js
@@ -1,5 +1,5 @@
 const { join } = require('path')
-const { excludeOptimize } = require('../package.json')
+const { external } = require('../package.json')
 
 /**
  * Vite shared config, assign alias and root dir
@@ -13,7 +13,7 @@ const config = {
     '/@/': join(__dirname, '../src/renderer')
   },
   optimizeDeps: {
-    exclude: excludeOptimize
+    exclude: external
   }
 }
 


### PR DESCRIPTION
Should "fix" #30 
The issue is rollup cannot handle circular dependencies like webpack (due to the esmodule behavior). So it cannot bundle some nodejs package, including the `electron-updater`.

This patch do the two things
1. Don't let rollup bundle the packages marked as `external` in package.json
2. Include those external packages into the electron build asar by [two-package-structure](https://www.electron.build/tutorials/two-package-structure)