### PR TITLE
fixed ipcRenderer sendSync api bug

### DIFF
--- a/electron-vue-next/src/preload/index.ts
+++ b/electron-vue-next/src/preload/index.ts
@@ -28,7 +28,7 @@ const _ipcRenderer: IpcRenderer = {
     return _ipcRenderer
   },
   send: (channel, ...args) => ipcRenderer.send(channel, ...args),
-  sendSync: (channel, ...args) => ipcRenderer.send(channel, ...args),
+  sendSync: (channel, ...args) => ipcRenderer.sendSync(channel, ...args),
   sendTo: (id, channel, ...args) => ipcRenderer.sendTo(id, channel, ...args),
   sendToHost: (channel, ...args) => ipcRenderer.sendToHost(channel, args),
   // event emitter methods


### PR DESCRIPTION
the ipcRenderer api should expose method sendSync from ipcRenderer.sendSync not from ipcRenderer.send