### PR TITLE
fix: ipc invoke raw payloads

### DIFF
--- a/electron-vue-next/src/renderer/composables/service.ts
+++ b/electron-vue-next/src/renderer/composables/service.ts
@@ -1,5 +1,6 @@
 import { useIpc } from './electron'
 import type { Services } from '/@main/services'
+import { toRaw } from 'vue'
 
 const { invoke } = useIpc()
 
@@ -7,7 +8,8 @@ function createProxy(service: string) {
   return new Proxy({} as any, {
     get(_, functionName) {
       return (...payloads: any[]) => {
-        return invoke('service:call', service, functionName as string, ...payloads)
+        const rawPayloads = payloads.map(e => toRaw(e));
+        return invoke('service:call', service, functionName as string, ...rawPayloads);
       }
     }
   })


### PR DESCRIPTION
Because we are using vue3, it is difficult to guarantee that Proxy will not be passed through ipc. [why?](https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args)

